### PR TITLE
Fix Bugs For Content Script Error

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -278,8 +278,9 @@ if (document.location.hostname.indexOf("facebook") != -1 || document.location.ho
 var list = document.querySelector('body');
 if (!list) {
     if (document.addEventListener) {
-        // Use the handy event callback
-        document.addEventListener("DOMContentLoaded",
+        if(chrome.storage){//check storage is accessible
+            // Use the handy event callback
+            document.addEventListener("DOMContentLoaded",
             function() {
                 chrome.storage.local.get("data", function(items) {
                     if (!chrome.runtime.error) {
@@ -291,17 +292,27 @@ if (!list) {
                     } 
                 });
             }, false);
+        } else {
+            document.addEventListener("DOMContentLoaded",
+            function() {
+                addObserver();
+            }, false);
+        }
     }
 } else {
-    chrome.storage.local.get("data", function(items) {
-        if (!chrome.runtime.error) {
-          //console.log(items);
-          var enableMUA = items.data;
-          if(enableMUA != "disable") {
-            convertTree(document.body);
-            addObserver();
-          }
-        } 
-    });
-    
+    if (chrome.storage) {//check storage is accessible
+        chrome.storage.local.get("data", function(items) {
+            if (!chrome.runtime.error) {
+              //console.log(items);
+              var enableMUA = items.data;
+              if(enableMUA != "disable") {
+                convertTree(document.body);
+                addObserver();
+              }
+            } 
+        });
+    } else {
+        convertTree(document.body);
+        addObserver();
+    }
 }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/9404824/16894734/c5df967e-4b85-11e6-9f27-e0cba1a353c7.png)
Content Script က နေ local storage ကို ဝင်လို့ မရလို့ converter အလုပ်မလုပ်တာကို ရှင်းထားပါတယ်။
ဗားရှင်း ၄၈ အထက်မှာမှ အလုပ်လုပ်မယ် တဲ့ အစ်ကို။
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/storage
အဲ့တာမို့လို့ MUA Switch ကို on off လုပ်တဲ့ ဖန်ရှင်က ၄၈ အောက်ဆိုရင် အလုပ်မလုပ်ပါဘူး။ 
off ထားရင်လည်း ပြောင်းနေမှာပါ။
