### PR TITLE
fix slow loading content scripts

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -277,27 +277,18 @@ if (document.location.hostname.indexOf("facebook") != -1 || document.location.ho
 
 var list = document.querySelector('body');
 if (!list) {
-    if (document.addEventListener) {
-        if(chrome.storage){//check storage is accessible
-            // Use the handy event callback
-            document.addEventListener("DOMContentLoaded",
-            function() {
-                chrome.storage.local.get("data", function(items) {
-                    if (!chrome.runtime.error) {
-                      //console.log(items);
-                      var enableMUA = items.data;
-                      if(enableMUA != "disable") {
-                        addObserver();
-                      }
-                    } 
-                });
-            }, false);
-        } else {
-            document.addEventListener("DOMContentLoaded",
-            function() {
+    if(chrome.storage){//check storage is accessible
+        chrome.storage.local.get("data", function(items) {
+            if (!chrome.runtime.error) {
+              //console.log(items);
+              var enableMUA = items.data;
+              if(enableMUA != "disable") {
                 addObserver();
-            }, false);
-        }
+              }
+            } 
+        });
+    } else {
+        addObserver();
     }
 } else {
     if (chrome.storage) {//check storage is accessible

--- a/manifest.json
+++ b/manifest.json
@@ -30,10 +30,10 @@
     "default_title": "Click here!"
   },
   "content_scripts": [ {
+      "matches": [ "*://*/*" ],
       "css": [ "zawgyi.css" ],
       "js": [ "parabaik.js", "converter.js" ],
-      "matches": [ "*://*/*" ],
-      "run_at": "document_idle"
+      "run_at": "document_end"
    } ],
 
   "permissions": [


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/9404824/16991477/b51d13a4-4ec1-11e6-88ba-a271932b4485.png)
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/content_scripts
အဲ့တာ မို့ Firefox မှာ document _end ပြောင်းသုံးပါတယ် အစ်ကို။
Google Chrome မှတော့ document_idle နဲ့ အဆင်ပြေပါတယ်။
နောက်ပြီးတော့ doucment_end မှာ run မှာဆိုတော့ DOMloaded ဆိုပြီးတော့ event တွဲစရာ မလိုတော့ဘူး ထင်လို့ဖြုတ်ထားပါတယ်။
ကျနော် စမ်းသုံးနေတာ အဆင်ပြေပါတယ်။ content script မြန်သွားတော့ facebook သုံးရတာ သိသာပါတယ်။
